### PR TITLE
Simplify pinning again.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,8 +24,8 @@ classifiers = [
 ]
 requires-python = ">= 3.7"
 dependencies = [
-    "matplotlib>=3.1,<4",
-    "sympy>=1.2,<2",
+    "matplotlib >= 3.1, <4",
+    "sympy >= 1.2, <2",
 ]
 dynamic = ["version"]
 

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ exclude_lines =
     if __name__ == .__main__.:
 
 [tox]
-envlist = py3{7,8,9,10,11}-{low,high}, flake8, mypy, black, pylint, pydocstyle, coverage, isort, ruff
+envlist = py3{7,8,9,10,11}, flake8, mypy, black, pylint, pydocstyle, coverage, isort, ruff
 isolated_build = True
 skip_missing_interpreters = True
 
@@ -33,17 +33,13 @@ deps =
   pytest
   coverage
   hypothesis
-  low: matplotlib==3.1
-  low: sympy==1.2
-  high: matplotlib<4
-  high: sympy<2
 commands = coverage run -m pytest -m "not slow"
 setenv =
   COVERAGE_FILE={toxworkdir}/.coverage.{envname}
 
 [testenv:coverage]
 deps = coverage
-depends = py37-low, py38-low, py39-low
+depends = py37, py38, py39, py310, py311
 parallel_show_output = True
 skip_install = True
 setenv = COVERAGE_FILE={toxworkdir}/.coverage


### PR DESCRIPTION
OK. Pinning is a thing. But there's many Python versions tested too.

And there's multiple OSes in the CI.

Happen that on Windows, matplotlib 3.1 does not build in Github CI, I don't want to know why.

There's a wheel for matplotlib 3.1 for Python 3.6 and 3.7, so the CI pass for the tuple (windows, Python 3.7, matplotlib 3.1), and fail for all other Python versions.

I don't want to end up tailoring the list of dependencies by Python version just to fit the specificities of GH CI. It would also looks like I'm doing the work of the package manager, I don't want to do it, let the computer do computer things.